### PR TITLE
fix: dedupe recent links and bump version to v1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Startpage is a **local-first browser start page** designed to replace the tradit
 
 Everything runs entirely in the browser — no accounts, no backend, no tracking. Search, widgets, notes, weather, and the integrated Startpage Agent live locally in your browser and adapt to your workflow and style.
 
-Version: **v1.11.2** · Live: https://julianverse.de/startpage/
+Version: **v1.11.3** · Live: https://julianverse.de/startpage/
 
 ## Core Features
 - Quick search: Multiple engines, bang shortcuts (`!g`, `!ddg`, `!bing`, `!yt`, `!wiki`, `!maps`), custom shortcuts, and autocomplete (bangs, shortcuts, recent searches, global wordlist + preset wordlist).
@@ -73,4 +73,3 @@ Optional automated E2E tests (Playwright/Cypress) can be placed under `tests/*.e
 
 ## License
 MIT License (see `LICENSE`).
-

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 
     <footer class="muted" style="display:flex; align-items:center; justify-content:space-between; gap:8px; margin-top:6px">
       <div data-i18n="footer.tagline">Local-first Dashboard · speichert nur im Browser (localStorage)</div>
-      <div>v1.11.2</div>
+      <div>v1.11.3</div>
     </footer>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -1814,9 +1814,31 @@
     const raw = store.get('recent', []);
     return Array.isArray(raw) ? raw : [];
   }
+  function normalizeRecentUrl(url){
+    const raw = String(url || '').trim();
+    if(!raw) return '';
+    try {
+      return new URL(raw, window.location.href).href;
+    } catch {
+      return raw;
+    }
+  }
+  function dedupeRecentEntries(list){
+    if(!Array.isArray(list)) return [];
+    const out = [];
+    const seenUrls = new Set();
+    list.forEach(entry=>{
+      if(!entry || typeof entry !== 'object') return;
+      const normalizedUrl = normalizeRecentUrl(entry.url);
+      if(!normalizedUrl || seenUrls.has(normalizedUrl)) return;
+      seenUrls.add(normalizedUrl);
+      out.push({ ...entry, url: normalizedUrl });
+    });
+    return out;
+  }
   function persistRecentEntries(list){
     const max = getRecentMax();
-    const trimmed = list.slice(0, max);
+    const trimmed = dedupeRecentEntries(list).slice(0, max);
     store.set('recent', trimmed);
     return trimmed;
   }


### PR DESCRIPTION
## Summary
  Deduplicates links in the Recent widget and bumps version to `v1.11.3`.                                                                                                                                                  
                                                                                                                                                                                                                           
## Changes                                                                                                                                                                                                               
  - Added URL-based deduplication for Recent entries in `script.js`                                                                                                                                                        
  - Kept hash fragments (`#...`) distinct, so different hashes remain separate entries                                                                                                                                     
  - Deduplication runs during persistence, cleaning existing duplicates automatically                                                                                                                                      
  - Updated version from `v1.11.2` to `v1.11.3` in `index.html` and `README.md`                                                                                                                                            
                                                                                                                                                                                                                           
## Manual Testing                                                                                                                                                                                                        
  - Set Recent limit to 50                                                                                                                                                                                                 
  - Repeated searches producing identical URLs                                                                                                                                                                             
  - Verified identical URLs appear only once                                                                                                                                                                               
  - Verified different hash URLs still appear as separate entries       