### PR TITLE
feat: localize preset descriptions

### DIFF
--- a/assets/data-presets.json
+++ b/assets/data-presets.json
@@ -2,70 +2,80 @@
   {
     "id": "starter",
     "name": "Starter",
-    "description": "Reset auf das Standard-Setup mit Default-Kacheln und neutralen Farben.",
+    "description": "Reset to the default setup with default tiles and neutral colors.",
+    "descriptionKey": "data.presets.catalog.starter.description",
     "file": "assets/presets/starter.json",
     "tags": ["neutral", "reset"]
   },
   {
     "id": "coding",
     "name": "Coding",
-    "description": "Dark-Setup mit Dev-Kacheln, Tech-Feeds, Neon City Hintergrund.",
+    "description": "Dark setup with developer tiles, tech feeds, and the Neon City background.",
+    "descriptionKey": "data.presets.catalog.coding.description",
     "file": "assets/presets/coding.json",
     "tags": ["dark", "dev"]
   },
   {
     "id": "gaming",
     "name": "Gaming",
-    "description": "Gaming/Streaming-Favoriten, Game-Feeds und Neon-Look.",
+    "description": "Gaming and streaming favorites, game feeds, and a neon look.",
+    "descriptionKey": "data.presets.catalog.gaming.description",
     "file": "assets/presets/gaming.json",
     "tags": ["dark", "games"]
   },
   {
     "id": "minimal",
     "name": "Minimal",
-    "description": "Hell oder Auto, Soft Minimal/transparent, Fokus auf Suche & Notizen.",
+    "description": "Light or auto theme, soft minimal transparency, focused on search and notes.",
+    "descriptionKey": "data.presets.catalog.minimal.description",
     "file": "assets/presets/minimal.json",
     "tags": ["light", "focus"]
   },
   {
     "id": "productivity",
     "name": "Productivity",
-    "description": "Klarer Solid-Stil, Todos/Notes/System an, Office/Dev Kacheln, Tech/News-Feeds.",
+    "description": "Clean solid style with todos, notes, system widgets, office and dev tiles, plus tech and news feeds.",
+    "descriptionKey": "data.presets.catalog.productivity.description",
     "file": "assets/presets/productivity.json",
     "tags": ["work", "auto"]
   },
   {
     "id": "reading",
     "name": "Reading",
-    "description": "Lese-Modus mit Soft Minimal, Pocket/Kindle/Feedly Kacheln, News-lastige Feeds.",
+    "description": "Reading mode with a soft minimal style, Pocket, Kindle, and Feedly tiles, plus news-heavy feeds.",
+    "descriptionKey": "data.presets.catalog.reading.description",
     "file": "assets/presets/reading.json",
     "tags": ["light", "news"]
   },
   {
     "id": "art",
     "name": "Art & Photo",
-    "description": "Visueller Look mit Art/Photo-Links, rotierendem Hintergrund und satten Farben.",
+    "description": "Visual style with art and photo links, rotating backgrounds, and rich colors.",
+    "descriptionKey": "data.presets.catalog.art.description",
     "file": "assets/presets/art.json",
     "tags": ["visual", "auto"]
   },
   {
     "id": "privacy",
     "name": "Privacy",
-    "description": "Privacy-orientiert: DDG first, schlanke Tiles, keine News, dunkler transparenter Stil.",
+    "description": "Privacy-first with DDG as default, lean tiles, no news, and a dark transparent style.",
+    "descriptionKey": "data.presets.catalog.privacy.description",
     "file": "assets/presets/privacy.json",
     "tags": ["privacy", "minimal"]
   },
   {
     "id": "student",
     "name": "Student",
-    "description": "Campus/Study Links, helle Karte, Notion/Overleaf/Moodle Tiles, Uni/Tech Feeds.",
+    "description": "Campus and study links, a light card layout, Notion, Overleaf, and Moodle tiles, plus university and tech feeds.",
+    "descriptionKey": "data.presets.catalog.student.description",
     "file": "assets/presets/student.json",
     "tags": ["study", "light"]
   },
   {
     "id": "finance",
     "name": "Finance",
-    "description": "Boerse/Portfolio Kacheln, Finanz-Feeds, dunkler Stil mit knackigen Akzenten.",
+    "description": "Market and portfolio tiles, finance feeds, and a dark style with sharp accents.",
+    "descriptionKey": "data.presets.catalog.finance.description",
     "file": "assets/presets/finance.json",
     "tags": ["finance", "dark"]
   }

--- a/assets/i18n/de-de.json
+++ b/assets/i18n/de-de.json
@@ -539,7 +539,39 @@
       "defaultLabel": "Voreinstellung {index}",
       "userDefault": "User Preset {index}",
       "userDescription": "Lokales Preset aus assets/user-presets/",
-      "tags": "(Tags: {tags})"
+      "tags": "(Tags: {tags})",
+      "catalog": {
+        "starter": {
+          "description": "Reset auf das Standard-Setup mit Default-Kacheln und neutralen Farben."
+        },
+        "coding": {
+          "description": "Dark-Setup mit Dev-Kacheln, Tech-Feeds und Neon-City-Hintergrund."
+        },
+        "gaming": {
+          "description": "Gaming- und Streaming-Favoriten, Game-Feeds und ein Neon-Look."
+        },
+        "minimal": {
+          "description": "Helles oder automatisches Theme, weiche minimale Transparenz, Fokus auf Suche und Notizen."
+        },
+        "productivity": {
+          "description": "Klarer Solid-Stil mit Todos, Notizen, System-Widgets, Office- und Dev-Kacheln sowie Tech- und News-Feeds."
+        },
+        "reading": {
+          "description": "Lesemodus mit weichem Minimalstil, Pocket-, Kindle- und Feedly-Kacheln sowie newslastigen Feeds."
+        },
+        "art": {
+          "description": "Visueller Stil mit Art- und Foto-Links, rotierenden Hintergründen und satten Farben."
+        },
+        "privacy": {
+          "description": "Privacy-first mit DDG als Standard, schlanken Kacheln, keinen News und einem dunklen transparenten Stil."
+        },
+        "student": {
+          "description": "Campus- und Study-Links, helles Kartenlayout, Notion-, Overleaf- und Moodle-Kacheln sowie Uni- und Tech-Feeds."
+        },
+        "finance": {
+          "description": "Markt- und Portfolio-Kacheln, Finanz-Feeds und ein dunkler Stil mit prägnanten Akzenten."
+        }
+      }
     }
   },
   "dialogs": {

--- a/assets/i18n/en-us.json
+++ b/assets/i18n/en-us.json
@@ -539,7 +539,39 @@
       "defaultLabel": "Preset {index}",
       "userDefault": "User preset {index}",
       "userDescription": "Local preset from assets/user-presets/",
-      "tags": " (Tags: {tags})"
+      "tags": " (Tags: {tags})",
+      "catalog": {
+        "starter": {
+          "description": "Reset to the default setup with default tiles and neutral colors."
+        },
+        "coding": {
+          "description": "Dark setup with developer tiles, tech feeds, and the Neon City background."
+        },
+        "gaming": {
+          "description": "Gaming and streaming favorites, game feeds, and a neon look."
+        },
+        "minimal": {
+          "description": "Light or auto theme, soft minimal transparency, focused on search and notes."
+        },
+        "productivity": {
+          "description": "Clean solid style with todos, notes, system widgets, office and dev tiles, plus tech and news feeds."
+        },
+        "reading": {
+          "description": "Reading mode with a soft minimal style, Pocket, Kindle, and Feedly tiles, plus news-heavy feeds."
+        },
+        "art": {
+          "description": "Visual style with art and photo links, rotating backgrounds, and rich colors."
+        },
+        "privacy": {
+          "description": "Privacy-first with DDG as default, lean tiles, no news, and a dark transparent style."
+        },
+        "student": {
+          "description": "Campus and study links, a light card layout, Notion, Overleaf, and Moodle tiles, plus university and tech feeds."
+        },
+        "finance": {
+          "description": "Market and portfolio tiles, finance feeds, and a dark style with sharp accents."
+        }
+      }
     }
   },
   "dialogs": {

--- a/script.js
+++ b/script.js
@@ -1321,6 +1321,12 @@
     };
   }
 
+  function getPresetDescription(preset){
+    if(!preset) return '';
+    const fallback = preset.description || (preset.source === 'user' ? t('data.presets.userApply') : t('data.presets.apply'));
+    return preset.descriptionKey ? t(preset.descriptionKey, null, fallback) : fallback;
+  }
+
   async function loadPresetManifest(url, source){
     try{
       const res = await fetch(url);
@@ -1436,7 +1442,7 @@
       const tags = Array.isArray(current.tags) ? [...current.tags] : [];
       if(current.source === 'user' && !tags.includes('user')) tags.unshift('user');
       const tagText = tags.length ? t('data.presets.tags', { tags: tags.join(', ') }) : '';
-      const description = current.description || (current.source === 'user' ? t('data.presets.userApply') : t('data.presets.apply'));
+      const description = getPresetDescription(current);
       meta.textContent = description + tagText;
       select.value = current.id || select.value;
     } else {
@@ -2859,7 +2865,7 @@
     const presets = await loadDataPresets();
     const current = presets.find(p => String(p.id||'') === select.value) || presets[0];
     if(current){
-      meta.textContent = current.description || t('onboarding.preset.meta');
+      meta.textContent = getPresetDescription(current) || t('onboarding.preset.meta');
     } else {
       meta.textContent = t('onboarding.preset.optional');
     }


### PR DESCRIPTION
## Summary

  Localize built-in data preset descriptions instead of rendering hardcoded manifest text directly in the UI.

  ## Changes

  - add `descriptionKey` entries for built-in presets in `assets/data-presets.json`
  - move built-in preset descriptions into `assets/i18n/en-us.json`
  - add matching German translations in `assets/i18n/de-de.json`
  - resolve preset descriptions through the i18n layer in settings and onboarding

  ## Why

  Built-in preset descriptions were stored directly in the manifest and shown as raw text, which caused them to appear in German for non-German
  users. This change makes preset descriptions language-aware and keeps them aligned with the existing localization system.

  ## Manual Testing

  - verified preset descriptions in the settings preset selector
  - verified preset descriptions in the onboarding preset selector
  - confirmed descriptions render via active locale
  - confirmed user presets still fall back to their manifest descriptions

  Closes #3