### PR TITLE
fix: add Julianverse Weather link

### DIFF
--- a/assets/i18n/de-de.json
+++ b/assets/i18n/de-de.json
@@ -87,6 +87,7 @@
     "setCity": "Setzen",
     "pickLocation": "Ort wählen…",
     "source": "Quelle: Open-Meteo",
+    "openApp": "In Julianverse Weather öffnen",
     "loading": "Lade Wetter...",
     "prompt": "Ort eingeben, um Wetter zu laden.",
     "tempEmpty": "—°C",
@@ -418,6 +419,7 @@
       "items": {
         "openMeteoForecast": "Wettervorhersagedaten für ausgewählte Orte.",
         "openMeteoGeocoding": "Stadt-/Standortsuche für das Wetter-Widget.",
+        "julianverseWeather": "Detailansicht der ausgewählten Wetter-Stadt.",
         "startpageProxy": "Proxy für Transport- und RSS-/News-Anfragen.",
         "transportRest": "Über den Proxy genutztes ÖPNV-Backend.",
         "googleFavicons": "Favicons für Favouritenkacheln.",

--- a/assets/i18n/en-us.json
+++ b/assets/i18n/en-us.json
@@ -87,6 +87,7 @@
     "setCity": "Set",
     "pickLocation": "Pick a location…",
     "source": "Source: Open-Meteo",
+    "openApp": "Open in Julianverse Weather",
     "loading": "Loading weather…",
     "prompt": "Enter a location to load weather.",
     "tempEmpty": "—°C",
@@ -347,6 +348,7 @@
       "items": {
         "openMeteoForecast": "Weather forecast data for selected locations.",
         "openMeteoGeocoding": "City/location lookup for the weather widget.",
+        "julianverseWeather": "Detailed view for the selected weather city.",
         "startpageProxy": "Proxy for transport and RSS/news requests.",
         "transportRest": "Public transport backend used via the proxy.",
         "googleFavicons": "Favicons for favorite tiles.",

--- a/index.html
+++ b/index.html
@@ -82,6 +82,9 @@
           </div>
         </div>
         <div class="weather-hourly" id="hourly"></div>
+        <div class="weather-app-link-wrap">
+          <a class="btn weather-app-link" id="weatherAppLink" href="https://julianverse.de/weather/" target="_blank" rel="noopener noreferrer" data-i18n="weather.openApp">In Julianverse Weather öffnen</a>
+        </div>
         <div class="muted" id="weatherFoot" style="margin-top:8px; font-size:12px" data-i18n="weather.source">Quelle: Open-Meteo</div>
       </section>
 

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -843,6 +843,24 @@
     try { el.innerHTML = weatherIconSVG(code); } catch { el.textContent = ''; }
   }
 
+  function updateWeatherAppLink(place, loc){
+    const link = $('#weatherAppLink');
+    if(!link) return;
+    const url = new URL('https://julianverse.de/weather/');
+    const name = String((loc && (loc.name || loc.city)) || place || '').trim();
+    const lat = Number(loc && loc.lat);
+    const lon = Number(loc && loc.lon);
+    if(Number.isFinite(lat) && Number.isFinite(lon)){
+      url.searchParams.set('lat', String(lat));
+      url.searchParams.set('lon', String(lon));
+      if(name) url.searchParams.set('name', name);
+    } else if(name){
+      url.searchParams.set('place', name);
+    }
+    link.href = url.toString();
+    link.hidden = !name;
+  }
+
   function parseWeatherTime(str, offsetSeconds){
     if(!str) return null;
     const base = new Date(str + 'Z');
@@ -952,10 +970,12 @@
     minmaxEl.textContent = t('weather.minmaxEmpty', null, '\u2014 / \u2014 \u00b0C');
     hourlyEl.innerHTML = '';
     updateWeatherIcon(null);
+    updateWeatherAppLink(city);
     if(!city) return;
 
     try {
       const loc = await resolveCity(city);
+      updateWeatherAppLink(city, loc);
       const url = `https://api.open-meteo.com/v1/forecast?latitude=${loc.lat}&longitude=${loc.lon}&hourly=temperature_2m,weathercode&current_weather=true&timezone=auto&daily=temperature_2m_max,temperature_2m_min&forecast_days=2`;
       const res = await fetch(url);
       if(!res.ok) throw new Error(t('weather.errors.fetchFailed'));
@@ -1429,4 +1449,3 @@
       if(!ul.children.length){ ul.innerHTML = `<li class="muted">${escapeHtml(t('news.noItems'))}</li>`; }
     }catch(e){ $('#newsList').innerHTML = `<li class="muted">${escapeHtml(t('common.loadError'))}</li>`; }
   }
-

--- a/scripts/settings-onboarding.js
+++ b/scripts/settings-onboarding.js
@@ -15,6 +15,11 @@
         url: 'https://geocoding-api.open-meteo.com/v1/search'
       },
       {
+        key: 'julianverseWeather',
+        name: 'Julianverse Weather',
+        url: 'https://julianverse.de/weather/'
+      },
+      {
         key: 'startpageProxy',
         name: 'Startpage Proxy API',
         url: 'https://api-startpage.julianverse.de/api'

--- a/style.css
+++ b/style.css
@@ -617,6 +617,8 @@
     .weather-hourly .chip-top { display:flex; width:100%; align-items:center; justify-content:space-between; gap:8px; font-weight:600 }
     .weather-hourly .chip-temp { font-variant-numeric:tabular-nums }
     .weather-hourly .chip-text { color: var(--muted); font-size:12px }
+    .weather-app-link-wrap { margin-top:10px; display:flex; justify-content:flex-end }
+    .weather-app-link { display:inline-flex; align-items:center; justify-content:center; padding:8px 12px; font-size:12px; text-decoration:none }
 
     /* Transport */
     .transport-top { display:flex; align-items:center; justify-content:space-between; gap:8px }


### PR DESCRIPTION
  ## Summary
  - add a weather widget link to Julianverse Weather below the 24h forecast
  - pass the selected weather location via `place`, or `lat`/`lon`/`name` after Open-Meteo resolution
  - document Julianverse Weather in the external sources guide

  ## Testing
  - `node --check scripts/dashboard.js`
  - `node --check scripts/settings-onboarding.js`
  - local HTTP smoke test on `http://127.0.0.1:4173/`