### PR TITLE
fix: restrict data transfers to Startpage storage keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Startpage is a **local-first browser start page** designed to replace the tradit
 
 Configuration and personal content stay in the browser without accounts or tracking. Network widgets only contact their documented data providers; transport and RSS use the Startpage proxy to handle browser API restrictions.
 
-Version: **v1.17.0** · Live: https://julianverse.de/startpage/
+Version: **v1.17.1** · Live: https://julianverse.de/startpage/
 
 ## Core Features
 - Quick search: Multiple engines, bang shortcuts (`!g`, `!ddg`, `!bing`, `!sx`, `!yt`, `!wiki`, `!maps`), custom shortcuts, and autocomplete (bangs, shortcuts, recent searches, global wordlist + preset wordlist).
@@ -24,7 +24,7 @@ Version: **v1.17.0** · Live: https://julianverse.de/startpage/
 - Layout and styling: Dark/Light/Auto theme, card styles (glass, solid, transparent, soft minimal), widget colors, dedicated header/search colors, and a "Tint widgets" action.
 - Command palette: `Ctrl/Cmd+K` for quick actions across settings, themes, widgets, data export/import, presets, and profiles.
 - Profiles: Named local snapshots of the full Startpage setup with create, rename, update, delete, apply, header quick switcher, and command palette support.
-- Data: Scoped JSON export/import with selection dialogs, import replace/merge modes, and data presets from `assets/presets/` (starter, coding, gaming, minimal, productivity, reading, art, privacy, student, finance); local user presets in `assets/user-presets/` are auto-detected.
+- Data: Scoped JSON export/import with selection dialogs, import replace/merge modes, and data presets from `assets/presets/` (starter, coding, gaming, minimal, productivity, reading, art, privacy, student, finance). Transfers are restricted to Startpage-owned storage keys, and local user presets in `assets/user-presets/` are auto-detected.
 - Accessibility and safety: Labelled modal dialogs, focus trapping/restoration, keyboard ordering, safe external URL handling, and text-only rendering for untrusted feed content.
 - Optional local Agent: An opt-in Ollama chat is available but disabled by default and is not required for any dashboard feature.
 
@@ -35,7 +35,8 @@ Version: **v1.17.0** · Live: https://julianverse.de/startpage/
 - `assets/` - Optional assets (wordlists, images, presets, i18n files).
 - `tests/` - Playwright browser smoke tests.
 - `package.json` / `playwright.config.js` - Test tooling; the application itself still has no build step.
-- `LICENSE` - MIT license.
+- `LICENSE` - MIT license for the project code and documentation.
+- `THIRD_PARTY_NOTICES.md` - Licenses and notices for bundled third-party assets.
 
 ## Local Development
 No build step is required. Start a local static server, for example:
@@ -57,7 +58,7 @@ Then open: `http://localhost:4173`.
 - Search and feeds: Enable/disable engines, configure custom `!shortcuts` with `{q}`, manage feed sources.
 - Widgets and layout: Visibility, weather cities (one city per line), default transport station, and reset controls. Start the visual editor from the header or Widget settings to arrange and resize cards directly.
 - Appearance (same settings area): Card style, widget colors, dedicated clock/search colors.
-- Data: Export/import selected local data scopes as JSON, choose merge or replace behavior on import, or load ready-made data presets (`assets/data-presets.json` + `assets/presets/*`).
+- Data: Export/import selected Startpage-owned data scopes as JSON, choose merge or replace behavior on import, or load ready-made data presets (`assets/data-presets.json` + `assets/presets/*`). Unrelated `localStorage` entries from the same origin are excluded.
 - Profiles: Create named setup snapshots, update them from the current state, switch from the header, and manage them in the Data tab.
 - Setup assistant: Opens on first run, can be skipped, and can be restarted in the Data tab.
 - Command palette: `Ctrl/Cmd+K` for fast actions, settings navigation, data actions, presets, and profile switching.
@@ -77,7 +78,7 @@ npx playwright install chromium
 npm test
 ```
 
-The eight current tests cover local persistence, deferred requests for hidden widgets, safe RSS rendering, height-adaptive news, transport delay formatting, saved layouts, the visual widget editor, and modal accessibility.
+The nine current tests cover local persistence, scoped data export, deferred requests for hidden widgets, safe RSS rendering, height-adaptive news, transport delay formatting, saved layouts, the visual widget editor, and modal accessibility.
 
 Manual smoke tests:
 - Verify search/bangs/shortcuts + autocomplete.
@@ -90,4 +91,4 @@ Manual smoke tests:
 - Clear localStorage and the Startpage IndexedDB database when re-testing migration-sensitive storage flows.
 
 ## License
-MIT License (see `LICENSE`).
+The original project code and documentation are available under the MIT License (see `LICENSE`). Bundled third-party assets remain under their respective licenses; see `THIRD_PARTY_NOTICES.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startpage",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startpage",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "devDependencies": {
         "@playwright/test": "1.61.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startpage",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "private": true,
   "scripts": {
     "test": "playwright test",

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -1441,13 +1441,12 @@
     },
     other: {
       labelKey: 'settings.data.exportScopes.other',
-      match: ()=> true
+      match: key => ['settings.tab', 'bg.url', 'profiles.items', 'profiles.activeId'].includes(key)
     }
   };
 
   function getDataScopeForKey(key){
-    const known = DATA_TRANSFER_SCOPE_ORDER.filter(scope => scope !== 'other');
-    return known.find(scope => DATA_EXPORT_SCOPES[scope].match(key)) || 'other';
+    return DATA_TRANSFER_SCOPE_ORDER.find(scope => DATA_EXPORT_SCOPES[scope].match(key)) || null;
   }
 
   function readLocalStorageData(scopes=DATA_TRANSFER_SCOPE_ORDER){
@@ -1456,7 +1455,8 @@
     for(let i=0;i<localStorage.length;i++){
       const k = localStorage.key(i);
       if(k.startsWith('cache.')) continue;
-      if(!allowed.has(getDataScopeForKey(k))) continue;
+      const scope = getDataScopeForKey(k);
+      if(!scope || !allowed.has(scope)) continue;
       try { data[k] = JSON.parse(localStorage.getItem(k)); } catch { data[k] = localStorage.getItem(k); }
     }
     return data;
@@ -1856,12 +1856,7 @@
   }
 
   function isStartpageDataKey(key){
-    if(!key) return false;
-    if(key === 'settings.tab' || key === UI_FONT_KEY || key === 'bg.url' || key === 'weather.coords') return true;
-    if(key === 'search.searxng.enabledMigration.v1') return true;
-    return Object.keys(DATA_EXPORT_SCOPES)
-      .filter(scope => scope !== 'other')
-      .some(scope => DATA_EXPORT_SCOPES[scope].match(key));
+    return !!getDataScopeForKey(key);
   }
 
   function getImportReplaceRemovalKeys(obj, scopes){
@@ -1880,7 +1875,8 @@
     const allowed = new Set(scopes || DATA_TRANSFER_SCOPE_ORDER);
     const out = {};
     Object.keys(obj || {}).forEach(key=>{
-      if(allowed.has(getDataScopeForKey(key))) out[key] = obj[key];
+      const scope = getDataScopeForKey(key);
+      if(scope && allowed.has(scope)) out[key] = obj[key];
     });
     return out;
   }

--- a/tests/startpage.e2e.spec.js
+++ b/tests/startpage.e2e.spec.js
@@ -24,6 +24,30 @@ test('loads the local dashboard and persists a todo', async ({ page })=>{
   await expect(page.locator('#todoList')).toContainText('Smoke test task');
 });
 
+test('exports only Startpage-owned localStorage entries', async ({ page })=>{
+  await seedStartpage(page, {
+    todos: [{ text:'Keep me', done:false }],
+    paymentMethod: 'redstone-bank',
+    lastReceipt: { method:'redstone-bank' }
+  });
+  await page.goto('/');
+  await page.locator('#openSettings').click();
+  await page.locator('[data-tab="data"]').click();
+  await page.locator('#exportData').click();
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.locator('#dataTransferApply').click();
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  const exported = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+
+  expect(exported.todos).toEqual([{ text:'Keep me', done:false }]);
+  expect(exported).not.toHaveProperty('paymentMethod');
+  expect(exported).not.toHaveProperty('lastReceipt');
+});
+
 test('does not request data or favicons for hidden widgets', async ({ page })=>{
   await seedStartpage(page, {
     widgets: { todo:true, notes:true, tiles:false, weather:false, transport:false, quote:false, recent:false, system:false, news:false }


### PR DESCRIPTION
## Summary

  - restrict data export to known Startpage-owned `localStorage` keys
  - ignore unrelated origin data during import
  - preserve supported Startpage data such as profiles and appearance settings
  - add a regression test for unrelated storage entries
  - update the README and bump the version to `1.17.1`

  ## Root cause

  The `other` export scope matched every remaining `localStorage` entry. As a result, data belonging to other applications on the same origin could be included in Startpage backups.

  ## Validation

  - `npm test`
  - 9 Playwright tests passed
  - verified that `paymentMethod` and `lastReceipt` are excluded while Startpage todos remain in the export

  Fixes #30